### PR TITLE
Default to email support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -75,12 +75,12 @@ class SupportSkill(NeonSkill):
         :param message: Message associated with request
         """
         user_profile = get_user_prefs(message)
-        if not user_profile["user"]["email"]:
-            # TODO: Ask to send to support@neon.ai?
+        email_addr = user_profile["user"]["email"]
+        if not email_addr:
             self.speak_dialog("no_email", private=True)
-            return
+            email_addr = self.support_email
         if self.ask_yesno("confirm_support",
-                          {"email": user_profile["user"]["email"]}) == "yes":
+                          {"email": email_addr}) == "yes":
             if user_profile["response_mode"].get("hesitation"):
                 self.speak_dialog("one_moment", private=True)
             diagnostic_info = self._get_support_info(message, user_profile)
@@ -90,18 +90,18 @@ class SupportSkill(NeonSkill):
             attachment_files = self._parse_attachments(self._get_log_files())
             if self.send_email(self.translate("email_title"),
                                self._format_email_body(diagnostic_info),
-                               message, user_profile["user"]["email"],
+                               message, email_addr,
                                attachments=attachment_files):
                 self.speak_dialog("complete",
-                                  {"email": user_profile["user"]["email"]},
+                                  {"email": email_addr},
                                   private=True)
                 return
             LOG.error("Email failed to send, retry without attachments")
             if self.send_email(self.translate("email_title"),
                                self._format_email_body(diagnostic_info),
-                               message, user_profile["user"]["email"]):
+                               message, email_addr):
                 self.speak_dialog("complete",
-                                  {"email": user_profile["user"]["email"]},
+                                  {"email": email_addr},
                                   private=True)
             else:
                 LOG.error(f"Email Failed to send!")

--- a/locale/en-us/dialog/complete.dialog
+++ b/locale/en-us/dialog/complete.dialog
@@ -1,1 +1,1 @@
-I've sent an email to {{email}} with debugging information and instructions for contacting support.
+I've sent an email to {{email}} with debugging information.

--- a/locale/en-us/dialog/confirm_support.dialog
+++ b/locale/en-us/dialog/confirm_support.dialog
@@ -1,1 +1,1 @@
-Would you like to create a troubleshooting package? This will send logs to you at {{email}}.
+Would you like to create a troubleshooting package? This will send a report to {{email}}.

--- a/locale/en-us/dialog/no_email.dialog
+++ b/locale/en-us/dialog/no_email.dialog
@@ -1,1 +1,1 @@
-I don't know your email address. You can tell me by saying 'Neon, my email address is...'
+I don't know your email address, but I can email support directly instead.

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -90,9 +90,10 @@ class TestSkill(unittest.TestCase):
         test_message = Message("test", {"utterance": "This is a test"},
                                {"klat_data": True, "username": "test_user",
                                 "user_profiles": [user_config]})
-        # Contact Support No Email
+        # Contact Support No Email Declined
         self.skill.handle_contact_support(test_message)
-        self.skill.speak_dialog.assert_called_with("no_email", private=True)
+        self.skill.speak_dialog.assert_any_call("no_email", private=True)
+
         # Contact Support Declined
         test_message.context["user_profiles"][0]["user"]["email"] = \
             "test@neon.ai"


### PR DESCRIPTION
# Description
Default send support emails to configured support email instead of asking user to provide an email address first
Update dialog and tests to match new behavior

# Issues
Closes #28

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->