### PR TITLE
Update attachment truncation to avoid missing attachments

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import json
+
 import shutil
 import sys
 import yaml
@@ -141,7 +141,6 @@ class SupportSkill(NeonSkill):
                     encode_file_to_base64_string(file)
             except Exception as e:
                 LOG.exception(e)
-        LOG.debug(f"Attachments Size={len(json.dumps(attachments))}")
         return attachments
 
     def _format_email_body(self, diagnostics: dict) -> str:

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+import json
 import shutil
 import sys
 import yaml
@@ -139,9 +139,9 @@ class SupportSkill(NeonSkill):
                 LOG.debug(f"{file} is {getsize(file)/1024/1024} MiB")
                 attachments[basename(file).replace('.log', '_log.txt')] = \
                     encode_file_to_base64_string(file)
-                LOG.debug(f"Attachments size={sys.getsizeof(attachments)/1024/1024} MiB")
             except Exception as e:
                 LOG.exception(e)
+        LOG.debug(f"Attachments Size={len(json.dumps(attachments))}")
         return attachments
 
     def _format_email_body(self, diagnostics: dict) -> str:

--- a/__init__.py
+++ b/__init__.py
@@ -130,10 +130,11 @@ class SupportSkill(NeonSkill):
                 byte_size = getsize(file)
                 if byte_size > 1000000:
                     LOG.info(f"{file} is >1MB, truncating")
-                    with open(file, 'r+') as f:
-                        lines = f.readlines()
+                    with open(file, 'rb+') as f:
+                        content = f.read()
+                        trunc = content[-1000000:].split(b'\n', 1)[1]
                         f.seek(0)
-                        f.writelines(lines[-50000:])
+                        f.write(trunc)
                         f.truncate()
 
                 attachments[basename(file).replace('.log', '_log.txt')] = \

--- a/__init__.py
+++ b/__init__.py
@@ -136,7 +136,7 @@ class SupportSkill(NeonSkill):
                         f.seek(0)
                         f.write(trunc)
                         f.truncate()
-
+                LOG.debug(f"{file} is {getsize(file)/1024} MiB")
                 attachments[basename(file).replace('.log', '_log.txt')] = \
                     encode_file_to_base64_string(file)
             except Exception as e:

--- a/__init__.py
+++ b/__init__.py
@@ -136,9 +136,10 @@ class SupportSkill(NeonSkill):
                         f.seek(0)
                         f.write(trunc)
                         f.truncate()
-                LOG.debug(f"{file} is {getsize(file)/1024} MiB")
+                LOG.debug(f"{file} is {getsize(file)/1024/1024} MiB")
                 attachments[basename(file).replace('.log', '_log.txt')] = \
                     encode_file_to_base64_string(file)
+                LOG.debug(f"Attachments size={sys.getsizeof(attachments)/1024/1024} MiB")
             except Exception as e:
                 LOG.exception(e)
         return attachments

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -36,6 +36,9 @@ from neon_utils.user_utils import get_default_user_config
 from neon_minerva.tests.skill_unit_test_base import SkillTestCase
 
 
+os.environ["TEST_SKILL_ENTRYPOINT"] = "skill-support_helper.neongeckocom"
+
+
 class TestSkill(SkillTestCase):
     def test_00_skill_init(self):
         # Test any parameters expected to be set in init or initialize methods
@@ -196,8 +199,11 @@ class TestSkill(SkillTestCase):
             original = f.readlines()
         with open(test_outfile, 'r') as f:
             truncated = f.readlines()
-        self.assertEqual(truncated, original[-50000:])
-        self.assertLess(getsize(test_outfile), input_size)
+        self.assertTrue(set(truncated) <= set(original))  # truncated is subset
+        self.assertIsInstance(int(truncated[0].split()[0]), int)
+        self.assertEqual(truncated[0].split()[1], '-')
+        self.assertEqual(truncated[-1], original[-1])
+        self.assertLess(getsize(test_outfile), 1000000)
         os.remove(test_outfile)
         os.remove(test_file)
 


### PR DESCRIPTION
# Description
Update logic and tests to take last 1MB of log files instead of approximating by lines

# Issues
Closes #81

# Other Notes
The [email proxy](https://github.com/NeonGeckoCom/neon_email_proxy) will attempt to send an email with all passed attachments. If this exceeds the maximum allowed by the email provider and the send fails, then all attachments are discarded.